### PR TITLE
Improved the MQTT settings in settings.cpp and mqtt.cpp

### DIFF
--- a/platformio/src/mqtt/mqtt.cpp
+++ b/platformio/src/mqtt/mqtt.cpp
@@ -92,7 +92,7 @@ void MQTT_Stuff::mqtt_reconnect()
 	Serial.println(WiFi.localIP());
 	Serial.println();
 	// Attempt to connect
-	if (mqtt_client.connect(settings.config.mqtt.device_name.c_str()))
+	if (mqtt_client.connect(settings.config.mqtt.device_name.c_str(), settings.config.mqtt.username.c_str(), settings.config.mqtt.password.c_str()))
 	{
 		Serial.println("** mqtt connected **");
 		// Subscribe

--- a/platformio/src/settings/settings.cpp
+++ b/platformio/src/settings/settings.cpp
@@ -263,7 +263,7 @@ bool Settings::load()
 
 	Serial.printf("Country: %s, utc offset is %u\n", config.country, config.utc_offset);
 
-	if (config.mqtt.broker_ip = "" || config.mqtt.broker_ip == "mqtt://192.168.1.70")
+	if (config.mqtt.broker_ip == "" || config.mqtt.broker_ip == "mqtt://192.168.1.70")
 	{
 		config.mqtt.broker_ip = "192.168.1.70";
 	}


### PR DESCRIPTION
The MQTT broker always defaults to the hardcoded one due to a comperission error in the if-statement in the settings.cpp. This is fixed.

The connection to the MQTT-broker does not use the username and password provided in the settings-webpage in mqtt.cpp. I changed the connection so it uses het provided username and password.